### PR TITLE
fix: typoed config variable

### DIFF
--- a/client/hospital.lua
+++ b/client/hospital.lua
@@ -69,7 +69,7 @@ local function putPlayerInBed(hospitalName, bedIndex, isRevive, skipOpenCheck)
         Wait(5)
         if isRevive then
             exports.qbx_core:Notify(Lang:t('success.being_helped'), 'success')
-            Wait(config.aiHealTime * 1000)
+            Wait(config.aiHealTimer * 1000)
             TriggerEvent("hospital:client:Revive")
         else
             CanLeaveBed = true


### PR DESCRIPTION
## Description

Missing letter caused you to be unable to revive.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
